### PR TITLE
Compile module on local installation and packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npm run format:check && jest -i",
     "format": "prettier --write $(head -1 prettier-globs)",
     "format:check": "prettier --list-different $(head -1 prettier-globs)",
-    "coverage": "rm -rf coverage && jest --coverage && open coverage/lcov-report/index.html"
+    "coverage": "rm -rf coverage && jest --coverage && open coverage/lcov-report/index.html",
+    "prepare": "npm run build"
   },
   "engines": {
     "node": ">=10.12.0"


### PR DESCRIPTION
Hi!

I thought that it would be nice to have a `prepare` script. This saves a manual `npm run build` when cloning the project.

It also allows users to directly import this module from Github.

With this pull request you can simply install the module from Github:
`npm i https://github.com/dirkvanvugt/baler.git#feature/add-prepare-script-for-building`

After installing you can run baler from the local directory by adding it to that respective `scripts` in the `package.json`.

This makes it easier to add the module to your project locally.

I hope this helps, keep up the good work!